### PR TITLE
The elevation parameter is needed on Lollipop ...

### DIFF
--- a/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
@@ -100,7 +100,9 @@ public class FloatingActionButton extends ImageButton {
 
     @Override
     public void setElevation(float elevation) {
-        // Use shadow configurations instead
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+            super.setElevation(elevation);
+        }
     }
 
     private int getCircleSize() {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
         <attr name="fab_showAnimation" format="reference" />
         <attr name="fab_hideAnimation" format="reference" />
         <attr name="fab_label" format="string" />
+        <attr name="fab_elevation" format="dimension" />
     </declare-styleable>
 
     <declare-styleable name="FloatingActionMenu">


### PR DESCRIPTION
because it determines the "order" of overlaying views. For example a view in FrameLayout is visible in front of another if it has greater elevation. Can't handle it if setting elevation is disabled (Overriden setElevation)