### PR TITLE
Add fab:menu_fab_label attribute to FloatingActionMenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Here are all the **FloatingActionMenu**'s xml attributes with their **default va
         fab:menu_labels_style="@style/YourCustomLabelsStyle"
         fab:menu_labels_position="left"
         fab:menu_openDirection="up"
-        fab:menu_backgroundColor="@android:color/transparent">
+        fab:menu_backgroundColor="@android:color/transparent"
+        fab:menu_fab_label="">
 
         <com.github.clans.fab.FloatingActionButton
             android:id="@+id/menu_item"

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -77,6 +77,7 @@
             <enum name="down" value="1" />
         </attr>
         <attr name="menu_backgroundColor" format="color" />
+        <attr name="menu_fab_label" format="string" />
     </declare-styleable>
 
 </resources>

--- a/sample/src/main/res/layout/floating_menus_activity.xml
+++ b/sample/src/main/res/layout/floating_menus_activity.xml
@@ -184,7 +184,8 @@
         fab:menu_labels_ellipsize="end"
         fab:menu_labels_singleLine="true"
         fab:menu_fab_size="mini"
-        fab:menu_openDirection="down">
+        fab:menu_openDirection="down"
+        fab:menu_fab_label="LABEL">
 
         <com.github.clans.fab.FloatingActionButton
             android:layout_width="wrap_content"
@@ -220,7 +221,8 @@
         android:paddingLeft="10dp"
         fab:menu_labels_ellipsize="end"
         fab:menu_labels_singleLine="true"
-        fab:menu_backgroundColor="#ccffffff">
+        fab:menu_backgroundColor="#ccffffff"
+        fab:menu_fab_label="LABEL">
 
         <com.github.clans.fab.FloatingActionButton
             android:id="@+id/fab1"
@@ -259,7 +261,8 @@
         fab:menu_labels_ellipsize="end"
         fab:menu_labels_singleLine="true"
         fab:menu_backgroundColor="#ccffffff"
-        fab:menu_labels_position="right">
+        fab:menu_labels_position="right"
+        fab:menu_fab_label="LABEL">
 
         <com.github.clans.fab.FloatingActionButton
             android:layout_width="wrap_content"


### PR DESCRIPTION
This PR introduces `fab:menu_fab_label` attribute to FloatingActionMenu.
(I developed this enhancement in order to achieve Google's Inbox app like FAB.)

![screenshot_2015-04-30-16-21-49](https://cloud.githubusercontent.com/assets/2552365/7408166/23fda036-ef55-11e4-885a-4b62840e1fe6.png)
