### PR TITLE
Add FloatingActionMenu.getMenuButton() method

### DIFF
--- a/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
@@ -820,4 +820,8 @@ public class FloatingActionMenu extends ViewGroup {
         removeView(fab);
         mButtonsCount--;
     }
+
+    public FloatingActionButton getMenuButton() {
+        return mMenuButton;
+    }
 }


### PR DESCRIPTION
This PR adds `FloatingActionMenu.getMenuButton()` method.


```java
final FloatingActionButton menu = ...;

menu.getMenuButton().setOnClickListener(
    new View.OnClickListener {
         void onClick(View v) {
             // --- we can handle app specific actions here ---

             menu.toggle(true);
         }
    }
);
```