### PR TITLE
Fix issue with FloatingActionMenu.mMenuOpened not getting updated

### DIFF
--- a/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
@@ -624,6 +624,13 @@ public class FloatingActionMenu extends ViewGroup {
                         }
                     }, delay);
                     delay += mAnimationDelayPerItem;
+                }else if(child.getVisibility() == GONE && i == 0){
+                    mUiHandler.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            mMenuOpened = true;
+                        }
+                    }, delay);
                 }
             }
 
@@ -674,6 +681,13 @@ public class FloatingActionMenu extends ViewGroup {
                         }
                     }, delay);
                     delay += mAnimationDelayPerItem;
+                } else if(child.getVisibility() == GONE && (i == mButtonsCount - 3)){
+                    mUiHandler.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            mMenuOpened = false;
+                        }
+                    }, delay);
                 }
             }
 


### PR DESCRIPTION
Fix issue where when opening or closing a FloatingActionMenu mMenuOpened would not get updated if a FloatingActionButton in a certain position had its visibility set to GONE.

For example when opening a menu if the FAB at position 0 had it's visibility set to GONE the menu will get stuck in an open state.

These same thing would happen when trying to close the menu.  If the FAB at position mButtonsCount - 3 had it's visibility set to GONE the menu will get stuck in a closed state.