### PR TITLE
[Fix] Build break due to a useless string resource 'app_name'

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Library</string>
-</resources>


### PR DESCRIPTION
This resource is generated by Android Studio by default. which may cause a build break: "error: variable app_name is already defined in class string"