### PR TITLE
setLabelText - setMenuButtonLabelText programmatically (issue #274)

### DIFF
--- a/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionButton.java
@@ -25,6 +25,7 @@ import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.os.SystemClock;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -509,6 +510,10 @@ public class FloatingActionButton extends ImageButton {
 
     Label getLabelView() {
         return (Label) getTag(R.id.fab_label);
+    }
+
+    void setLabelView(Label label) {
+        setTag(R.id.fab_label, label);
     }
 
     void setColors(int colorNormal, int colorPressed, int colorRipple) {
@@ -1078,6 +1083,7 @@ public class FloatingActionButton extends ImageButton {
         TextView labelView = getLabelView();
         if (labelView != null) {
             labelView.setText(text);
+            labelView.setVisibility(TextUtils.isEmpty(text) ? INVISIBLE : VISIBLE);
         }
     }
 

--- a/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
@@ -476,9 +476,8 @@ public class FloatingActionMenu extends ViewGroup {
     private void addLabel(FloatingActionButton fab) {
         String text = fab.getLabelText();
 
-        if (TextUtils.isEmpty(text)) return;
-
         final Label label = new Label(mLabelsContext);
+        label.setVisibility(TextUtils.isEmpty(text) ? INVISIBLE : VISIBLE);
         label.setClickable(true);
         label.setFab(fab);
         label.setShowAnimation(AnimationUtils.loadAnimation(getContext(), mLabelsShowAnimation));
@@ -527,7 +526,7 @@ public class FloatingActionMenu extends ViewGroup {
         label.setOnClickListener(fab.getOnClickListener());
 
         addView(label);
-        fab.setTag(R.id.fab_label, label);
+        fab.setLabelView(label);
     }
 
     private void setLabelEllipsize(Label label) {
@@ -655,8 +654,8 @@ public class FloatingActionMenu extends ViewGroup {
                                 fab.show(animate);
                             }
 
-                            Label label = (Label) fab.getTag(R.id.fab_label);
-                            if (label != null && label.isHandleVisibilityChanges()) {
+                            Label label = fab.getLabelView();
+                            if (label != null && label.isHandleVisibilityChanges() && !TextUtils.isEmpty(label.getText())) {
                                 label.show(animate);
                             }
                         }
@@ -711,8 +710,8 @@ public class FloatingActionMenu extends ViewGroup {
                                 fab.hide(animate);
                             }
 
-                            Label label = (Label) fab.getTag(R.id.fab_label);
-                            if (label != null && label.isHandleVisibilityChanges()) {
+                            Label label = fab.getLabelView();
+                            if (label != null && label.isHandleVisibilityChanges() && !TextUtils.isEmpty(label.getText())) {
                                 label.hide(animate);
                             }
                         }


### PR DESCRIPTION
fixes issues with FloatingActionButton.setLabelText and FloatingActionMenu.setMenuButtonlabelText (see related issue #274 ).

If FloatingActionButton was set in xml without the fab:fab_label attribute (fab:menu_fab_label for FloatingActionMenu respectively) the label was not created so it's text couldn't be changed later programmatically.

Fixed by adding the label and setting it's visibility to INVISIBLE. 
Another check is added when calling FloatingActionMenu open - close methods to verify that the label should be shown.