### PR TITLE
Add default behavior with Snakebars (FloatingActionMenu)

### DIFF
--- a/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
+++ b/library/src/main/java/com/github/clans/fab/FloatingActionMenu.java
@@ -10,6 +10,9 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.Snackbar;
+import android.support.v4.view.ViewCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -23,11 +26,13 @@ import android.view.animation.AnimationUtils;
 import android.view.animation.AnticipateInterpolator;
 import android.view.animation.Interpolator;
 import android.view.animation.OvershootInterpolator;
+import android.util.AttributeSet;
 import android.widget.ImageView;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@CoordinatorLayout.DefaultBehavior(FloatingActionMenu.Behavior.class)
 public class FloatingActionMenu extends ViewGroup {
 
     private static final int ANIMATION_DURATION = 300;
@@ -1012,5 +1017,38 @@ public class FloatingActionMenu extends ViewGroup {
 
     public void setOnMenuButtonLongClickListener(OnLongClickListener longClickListener) {
         mMenuButton.setOnLongClickListener(longClickListener);
+    }
+    
+    /**
+     * Behavior designed for use with {@link FloatingActionMenu} instances. Its main function
+     * is to move {@link FloatingActionMenu} views so that any displayed {@link Snackbar}s do
+     * not cover them.
+     */
+    public static class Behavior extends CoordinatorLayout.Behavior<FloatingActionMenu> {
+        public Behavior(){
+        super();
+    }
+
+    public Behavior(Context context, AttributeSet attrs){
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean layoutDependsOn(CoordinatorLayout parent, FloatingActionMenu child, View dependency) {
+        return dependency instanceof Snackbar.SnackbarLayout;
+    }
+
+    @Override
+    public boolean onDependentViewChanged(CoordinatorLayout parent, FloatingActionMenu child, View dependency) {
+        float translationY = Math.min(0, ViewCompat.getTranslationY(dependency) - dependency.getHeight());
+        ViewCompat.setTranslationY(child, translationY);
+        return true;
+    }
+
+    @Override
+    public void onDependentViewRemoved(CoordinatorLayout parent, FloatingActionMenu child, View dependency) {
+        ViewCompat.animate(child).translationY(0).start();
+
+    }
     }
 }


### PR DESCRIPTION
Its main function is to move FloatingActionMenu views so that any displayed Snackbars do not cover them.
No need to add layout_behavior in xml as it added by default by annotating the class.